### PR TITLE
publish Endpoint bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "lib/appinsights.js"
   ],
   "dependencies": {
-    "applicationinsights": "~0.15.16"
+    "applicationinsights": "~0.17.2"
   },
   "devDependencies": {
     "assert": "1.3.0",


### PR DESCRIPTION
**Expect** : Publish statd data to application insight.
**Actual**: Failed to publish. 
**Error**: The document is moved. The endpoint 'http' protocol it was publishing throwing a redirection response.
**_Change_** : upgrade the applicationinsights dependency to 0.17.2 which change the protocol to https.
The application endpoint doesn't accept http request and the fix was added with release 0.16.0.